### PR TITLE
Package data

### DIFF
--- a/icd/__init__.py
+++ b/icd/__init__.py
@@ -3,6 +3,6 @@ from icd.icd_to_comorbidities import icd_to_comorbidities
 from icd.long_to_short_transformation import long_to_short_transformation
 
 
-__version__ = '0.1.1'
+__version__ = '0.1.3'
 __author__ = 'Mark Hoffmann <markkhoffmann@gmail.com>'
 __all__ = []

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="icd",
-    version="0.1.2",
+    version="0.1.3",
     url="https://github.com/mark-hoffmann/icd",
 
     author="Mark Hoffmann",

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,8 @@ setuptools.setup(
     packages=setuptools.find_packages(),
 
     install_requires=['pandas'],
+    package_data={'icd': ['comorbidity_mappings/*.json']},
+    include_package_data=True,
 
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
Added `package_data` into the `setup.py` script so that the out of the box comorbidity mappings are available at a pip install.